### PR TITLE
improvement: Bump to okgo v1.50.0 to use NewCreatorWithMultiCPU and denote compiles compiles.MultiCPU is true 

### DIFF
--- a/changelog/@unreleased/pr-350.v2.yml
+++ b/changelog/@unreleased/pr-350.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Bump to okgo v1.50.0 to use NewCreatorWithMultiCPU and denote compiles
+    compiles.MultiCPU is true
+  links:
+  - https://github.com/palantir/godel-okgo-asset-compiles/pull/350

--- a/compiles/compiles.go
+++ b/compiles/compiles.go
@@ -21,4 +21,5 @@ import (
 const (
 	TypeName okgo.CheckerType     = "compiles"
 	Priority okgo.CheckerPriority = 0
+	MultiCPU okgo.CheckerMultiCPU = true
 )

--- a/compiles/creator/creator.go
+++ b/compiles/creator/creator.go
@@ -21,9 +21,10 @@ import (
 )
 
 func Compiles() checker.Creator {
-	return checker.NewCreator(
+	return checker.NewCreatorWithMultiCPU(
 		compiles.TypeName,
 		compiles.Priority,
+		compiles.MultiCPU,
 		func(cfgYML []byte) (okgo.Checker, error) {
 			return checker.NewAmalgomatedChecker(compiles.TypeName, checker.ParamPriority(compiles.Priority),
 				checker.ParamLineParserWithWd(

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/palantir/amalgomate v1.38.0
 	github.com/palantir/go-compiles v1.21.0
 	github.com/palantir/godel/v2 v2.101.0
-	github.com/palantir/okgo v1.48.0
+	github.com/palantir/okgo v1.50.0
 	github.com/palantir/pkg/cobracli v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/palantir/go-compiles v1.21.0 h1:v/rJ2lIPt4bV1WIvp0z4uKY62joZevsS+9rFz
 github.com/palantir/go-compiles v1.21.0/go.mod h1:sZCcPuxvw0Pd6Vx7Jfo7lho4cD6TbYdLEmB0nX6qhdU=
 github.com/palantir/godel/v2 v2.101.0 h1:5iF+av0TpeR0TX8kt06mz/9iQwudUYGFFtXmVG0EkaQ=
 github.com/palantir/godel/v2 v2.101.0/go.mod h1:/tkNvreQu//T5AtzDvHYCQUxLtJFM+2fTRAIMLl3ZX8=
-github.com/palantir/okgo v1.48.0 h1:Gw3Di7GC6FhZLqvwzSYtDBLJV0PpYP1EL77QLsAakVk=
-github.com/palantir/okgo v1.48.0/go.mod h1:UwU5nQX7wiRoSL4zUf5YRztUvWTInbFIB0MEq/qo0Ik=
+github.com/palantir/okgo v1.50.0 h1:U/oH1UmTEySEF7xt7aOBzTM1T0zCz13fi2TAxmRQWgQ=
+github.com/palantir/okgo v1.50.0/go.mod h1:UwU5nQX7wiRoSL4zUf5YRztUvWTInbFIB0MEq/qo0Ik=
 github.com/palantir/pkg v1.1.0 h1:0EhrSUP8oeeh3MUvk7V/UU7WmsN1UiJNTvNj0sN9Cpo=
 github.com/palantir/pkg v1.1.0/go.mod h1:KC9srP/9ssWRxBxFCIqhUGC4Jt7OJkWRz0Iqehup1/c=
 github.com/palantir/pkg/cobracli v1.2.0 h1:hANp5fUB5cX90SVri97Apz4xB3BqnZw0gP2jMQ34G8Y=

--- a/vendor/github.com/palantir/okgo/checker/amalgomated_helpers.go
+++ b/vendor/github.com/palantir/okgo/checker/amalgomated_helpers.go
@@ -42,6 +42,12 @@ func ParamPriority(priority okgo.CheckerPriority) AmalgomatedCheckerParam {
 	})
 }
 
+func ParamMultiCPU(multiCPU okgo.CheckerMultiCPU) AmalgomatedCheckerParam {
+	return paramFunc(func(c *amalgomatedChecker) {
+		c.multiCPU = multiCPU
+	})
+}
+
 func ParamLineParserWithWd(lineParserWithWd func(line, wd string) okgo.Issue) AmalgomatedCheckerParam {
 	return paramFunc(func(c *amalgomatedChecker) {
 		c.lineParserWithWd = lineParserWithWd
@@ -77,6 +83,7 @@ func NewAmalgomatedChecker(typeName okgo.CheckerType, params ...AmalgomatedCheck
 type amalgomatedChecker struct {
 	typeName              okgo.CheckerType
 	priority              okgo.CheckerPriority
+	multiCPU              okgo.CheckerMultiCPU
 	lineParserWithWd      func(line, wd string) okgo.Issue
 	includeProjectDirFlag bool
 	args                  []string
@@ -88,6 +95,10 @@ func (c *amalgomatedChecker) Type() (okgo.CheckerType, error) {
 
 func (c *amalgomatedChecker) Priority() (okgo.CheckerPriority, error) {
 	return c.priority, nil
+}
+
+func (c *amalgomatedChecker) MultiCPU() (okgo.CheckerMultiCPU, error) {
+	return c.multiCPU, nil
 }
 
 func (c *amalgomatedChecker) Check(pkgPaths []string, projectDir string, stdout io.Writer) {

--- a/vendor/github.com/palantir/okgo/checker/assetapi.go
+++ b/vendor/github.com/palantir/okgo/checker/assetapi.go
@@ -34,6 +34,7 @@ func AssetRootCmd(creator Creator, upgradeConfigFn pluginapi.UpgradeConfigFn, sh
 	creatorFn := creator.Creator()
 	rootCmd.AddCommand(newTypeCmd(checkerType))
 	rootCmd.AddCommand(newPriorityCmd(creator.Priority()))
+	rootCmd.AddCommand(newMultiCPUCmd(creator.MultiCPU()))
 	rootCmd.AddCommand(newVerifyConfigCmd(creatorFn))
 	rootCmd.AddCommand(newCheckCmd(creatorFn))
 	rootCmd.AddCommand(newRunCheckCmdCmd(creatorFn))
@@ -67,6 +68,23 @@ func newPriorityCmd(priority okgo.CheckerPriority) *cobra.Command {
 		Short: "Print the priority of the checker",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputJSON, err := json.Marshal(priority)
+			if err != nil {
+				return errors.Wrapf(err, "failed to marshal output as JSON")
+			}
+			cmd.Print(string(outputJSON))
+			return nil
+		},
+	}
+}
+
+const multiCPUCmdName = "multicpu"
+
+func newMultiCPUCmd(cpu okgo.CheckerMultiCPU) *cobra.Command {
+	return &cobra.Command{
+		Use:   multiCPUCmdName,
+		Short: "Print whether the check uses multiple CPUs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputJSON, err := json.Marshal(cpu)
 			if err != nil {
 				return errors.Wrapf(err, "failed to marshal output as JSON")
 			}

--- a/vendor/github.com/palantir/okgo/checker/checker_asset.go
+++ b/vendor/github.com/palantir/okgo/checker/checker_asset.go
@@ -30,6 +30,7 @@ type assetChecker struct {
 	cfgYML          string
 	checkerType     okgo.CheckerType
 	checkerPriority okgo.CheckerPriority
+	checkerMultiCPU okgo.CheckerMultiCPU
 }
 
 func (c *assetChecker) Type() (okgo.CheckerType, error) {
@@ -38,6 +39,10 @@ func (c *assetChecker) Type() (okgo.CheckerType, error) {
 
 func (c *assetChecker) Priority() (okgo.CheckerPriority, error) {
 	return c.checkerPriority, nil
+}
+
+func (c *assetChecker) MultiCPU() (okgo.CheckerMultiCPU, error) {
+	return c.checkerMultiCPU, nil
 }
 
 func (c *assetChecker) VerifyConfig() error {

--- a/vendor/github.com/palantir/okgo/checker/checkers.go
+++ b/vendor/github.com/palantir/okgo/checker/checkers.go
@@ -34,12 +34,14 @@ type CreatorFunction func(cfgYML []byte) (okgo.Checker, error)
 type Creator interface {
 	Type() okgo.CheckerType
 	Priority() okgo.CheckerPriority
+	MultiCPU() okgo.CheckerMultiCPU
 	Creator() CreatorFunction
 }
 
 type creatorStruct struct {
 	checkerType okgo.CheckerType
 	priority    okgo.CheckerPriority
+	multiCPU    okgo.CheckerMultiCPU
 	creator     CreatorFunction
 }
 
@@ -51,14 +53,27 @@ func (c *creatorStruct) Priority() okgo.CheckerPriority {
 	return c.priority
 }
 
+func (c *creatorStruct) MultiCPU() okgo.CheckerMultiCPU {
+	return c.multiCPU
+}
+
 func (c *creatorStruct) Creator() CreatorFunction {
 	return c.creator
 }
 
 func NewCreator(checkerType okgo.CheckerType, priority okgo.CheckerPriority, creatorFn CreatorFunction) Creator {
+	return NewCreatorWithMultiCPU(checkerType, priority, false, creatorFn)
+}
+
+func NewCreatorWithMultiCPU(
+	checkerType okgo.CheckerType,
+	priority okgo.CheckerPriority,
+	multiCPU okgo.CheckerMultiCPU,
+	creatorFn CreatorFunction) Creator {
 	return &creatorStruct{
 		checkerType: checkerType,
 		priority:    priority,
+		multiCPU:    multiCPU,
 		creator:     creatorFn,
 	}
 }
@@ -73,17 +88,19 @@ func AssetCheckerCreators(assetPaths ...string) ([]Creator, []okgo.ConfigUpgrade
 	}
 	for _, currAssetPath := range assetPaths {
 		currAssetPath := currAssetPath
-		typeAndPriority := typeAndPriorities[currAssetPath]
-		checkerType := typeAndPriority.checkerType
-		checkerPriority := typeAndPriority.checkerPriority
+		checkerMetadata := typeAndPriorities[currAssetPath]
+		checkerType := checkerMetadata.checkerType
+		checkerPriority := checkerMetadata.checkerPriority
+		checkerMultiCPU := checkerMetadata.checkerMultiCPU
 		checkerTypeToAssets[checkerType] = append(checkerTypeToAssets[checkerType], currAssetPath)
-		checkerCreators = append(checkerCreators, NewCreator(checkerType, checkerPriority,
+		checkerCreators = append(checkerCreators, NewCreatorWithMultiCPU(checkerType, checkerPriority, checkerMultiCPU,
 			func(cfgYML []byte) (okgo.Checker, error) {
 				newChecker := assetChecker{
 					assetPath:       currAssetPath,
 					cfgYML:          string(cfgYML),
 					checkerType:     checkerType,
 					checkerPriority: checkerPriority,
+					checkerMultiCPU: checkerMultiCPU,
 				}
 				if err := newChecker.VerifyConfig(); err != nil {
 					return nil, err
@@ -110,13 +127,14 @@ func AssetCheckerCreators(assetPaths ...string) ([]Creator, []okgo.ConfigUpgrade
 	return checkerCreators, configUpgraders, nil
 }
 
-type typeAndPriority struct {
+type checkerMetadata struct {
 	checkerType     okgo.CheckerType
 	checkerPriority okgo.CheckerPriority
+	checkerMultiCPU okgo.CheckerMultiCPU
 }
 
-func determineTypeAndPriorityForPaths(assetPaths []string) (map[string]typeAndPriority, error) {
-	typeAndPriorities := make(map[string]typeAndPriority)
+func determineTypeAndPriorityForPaths(assetPaths []string) (map[string]checkerMetadata, error) {
+	typeAndPriorities := make(map[string]checkerMetadata)
 	var (
 		mapLock sync.Mutex
 		g       errgroup.Group
@@ -140,28 +158,29 @@ func determineTypeAndPriorityForPaths(assetPaths []string) (map[string]typeAndPr
 	return typeAndPriorities, nil
 }
 
-func determineTypeAndPriority(assetPath string) (typeAndPriority, error) {
+func determineTypeAndPriority(assetPath string) (checkerMetadata, error) {
 	nameCmd := exec.Command(assetPath, typeCmdName)
 	outputBytes, err := runCommand(nameCmd)
 	if err != nil {
-		return typeAndPriority{}, err
+		return checkerMetadata{}, err
 	}
 	var checkerType okgo.CheckerType
 	if err := json.Unmarshal(outputBytes, &checkerType); err != nil {
-		return typeAndPriority{}, errors.Wrapf(err, "failed to unmarshal JSON")
+		return checkerMetadata{}, errors.Wrapf(err, "failed to unmarshal JSON")
 	}
 	priorityCmd := exec.Command(assetPath, priorityCmdName)
 	outputBytes, err = runCommand(priorityCmd)
 	if err != nil {
-		return typeAndPriority{}, err
+		return checkerMetadata{}, err
 	}
 	var checkerPriority okgo.CheckerPriority
 	if err := json.Unmarshal(outputBytes, &checkerPriority); err != nil {
-		return typeAndPriority{}, errors.Wrapf(err, "failed to unmarshal JSON")
+		return checkerMetadata{}, errors.Wrapf(err, "failed to unmarshal JSON")
 	}
-	return typeAndPriority{
+	return checkerMetadata{
 		checkerType:     checkerType,
 		checkerPriority: checkerPriority,
+		checkerMultiCPU: false,
 	}, nil
 }
 

--- a/vendor/github.com/palantir/okgo/okgo/checker.go
+++ b/vendor/github.com/palantir/okgo/okgo/checker.go
@@ -27,12 +27,17 @@ import (
 
 type CheckerPriority int
 
+type CheckerMultiCPU bool
+
 type Checker interface {
 	// Type returns the type of this Checker.
 	Type() (CheckerType, error)
 
 	// Priority returns the priority of the check. A lower number indicates a higher priority (will be run earlier).
 	Priority() (CheckerPriority, error)
+
+	// MultiCPU returns if the check uses multiple CPUs in its check command
+	MultiCPU() (CheckerMultiCPU, error)
 
 	// Check runs the check on the specified packages and writes the output to the provided io.Writer. All output
 	// written to the writer must be the JSON-serialized form of Issue, where there is one issue per line. Note that

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -101,7 +101,7 @@ github.com/palantir/godel/v2/godelgetter
 github.com/palantir/godel/v2/pkg/osarch
 github.com/palantir/godel/v2/pkg/products
 github.com/palantir/godel/v2/pkg/versionedconfig
-# github.com/palantir/okgo v1.48.0
+# github.com/palantir/okgo v1.50.0
 ## explicit; go 1.21
 github.com/palantir/okgo/checker
 github.com/palantir/okgo/okgo


### PR DESCRIPTION
- Bump to okgo v1.50.0 to use NewCreatorWithMultiCPU and denote compiles compiles.MultiCPU is true
- To help handle Occasionally checks take an extremely long time to run while running check.Run with parallelism  okgo#339


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

